### PR TITLE
Don't skip win/py27 build.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
   {{ hash_type }}: {{ hash_val }}
 
 build:
-  skip: True  # [py2k and win]
   entry_points:
     - girder-server = girder.__main__:main
     - girder-install = girder.utility.install:main


### PR DESCRIPTION
Now that we have snakebite, we should be able to make girder for windows